### PR TITLE
Potential fix for #8, Exception when inserting NULL in a ForeignKeyField

### DIFF
--- a/src/src/com/orm/androrm/ForeignKeyField.java
+++ b/src/src/com/orm/androrm/ForeignKeyField.java
@@ -135,9 +135,13 @@ public class ForeignKeyField<T extends Model> extends DataField<T> implements Re
 
 	@Override
 	public void putData(String key, ContentValues values) {
-		values.put(key, mReference);
+		if (mReference == 0) {
+			values.putNull(key);
+		} else {
+			values.put(key, mReference);
+		}
 	}
-	
+
 	/**
 	 * When models are deleted you may wish to also release
 	 * all references to other models on the instance in order


### PR DESCRIPTION
For #8, I believe what was happening was that `putData` was using the integer `0` which didn't exist in the database, hence the constraint error. This is fixed by using null when `mReference` is `0`, which is presumably when there is no foreign key set.

I haven't tested it, but when a foreign key reference is removed, this should correctly invalidate it too.
